### PR TITLE
perf: Lazy load component context during tree building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 Release Notes for Component Library plugin
 
-1.0.0 - 2024-09-16
+## 1.1.0 - 2026-02-26
+
+### Added
+- Search bar with keyboard shortcut for quick component lookup (#25)
+- Support for referencing nested context in component configs (#36)
+- Configurable preview component handle setting (#38)
+- Markdown documentation tab for components (#17)
+- Resizable preview pane splitter (#31)
+- Welcome page and error page styling (#30)
+- Library browser icon (#28)
+- Option to disable the component library browser (#18)
+- Hidden components and directories via config (#15)
+- Virtual component variants (#15)
+- Craft CMS 4.x compatibility (#23)
+
+### Fixed
+- Wrong prop name on exception handler
+- Plugin init log removed on startup
+- Various stability fixes for preview rendering and toolbar loading
+
+### Performance
+- Lazy load component context during tree building, significantly improving load times for large component libraries (#49)
+
+## 1.0.0 - 2024-09-16
 
 First public release.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "madebyraygun/craft-component-library",
   "description": "A fully-integrated component library system for Craft CMS",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "craft-plugin",
   "require": {
     "php": ">=8.2",

--- a/src/helpers/Context.php
+++ b/src/helpers/Context.php
@@ -41,8 +41,7 @@ class Context
         if ($parts->isVariant) {
             return [];
         }
-        // Read config file directly instead of using getComponentConfig()
-        // to avoid unnecessary context processing during tree building
+        // Read config file directly to avoid name normalization overhead in getComponentConfig()
         $config = self::readConfigFile($name);
         $variants = $config['variants'] ?? [];
         $results = [];
@@ -116,11 +115,11 @@ class Context
         $parts = Component::parseComponentParts($name);
         $config = self::readConfigFile($name);
 
-        // For variants, get variant-specific title if available
+        // For variants, replace config with variant-specific data (matching getComponentConfig behavior)
         if ($parts->isVariant && isset($config['variants'])) {
             $variantConfig = self::getVariantInConfig($config, $parts->name);
             if ($variantConfig) {
-                $config = array_merge($config, $variantConfig);
+                $config = $variantConfig;
             }
         }
 

--- a/src/helpers/Context.php
+++ b/src/helpers/Context.php
@@ -41,7 +41,9 @@ class Context
         if ($parts->isVariant) {
             return [];
         }
-        $config = self::getComponentConfig($name);
+        // Read config file directly instead of using getComponentConfig()
+        // to avoid unnecessary context processing during tree building
+        $config = self::readConfigFile($name);
         $variants = $config['variants'] ?? [];
         $results = [];
         $info = pathinfo($name);
@@ -102,6 +104,33 @@ class Context
         unset($config['variants']);
         $settings = self::setConfigDefaults($config);
         return (object)$settings;
+    }
+
+    /**
+     * Get only the minimal settings needed for tree display (title, hidden).
+     * This method avoids parsing full context and resolving references,
+     * providing significant performance improvements for large component libraries.
+     */
+    public static function getTreeSettings(string $name): object
+    {
+        $parts = Component::parseComponentParts($name);
+        $config = self::readConfigFile($name);
+
+        // For variants, get variant-specific title if available
+        if ($parts->isVariant && isset($config['variants'])) {
+            $variantConfig = self::getVariantInConfig($config, $parts->name);
+            if ($variantConfig) {
+                $config = array_merge($config, $variantConfig);
+            }
+        }
+
+        $title = $config['title'] ?? $config['name'] ?? $parts->name;
+        $title = StringHelper::humanize($title);
+
+        return (object) self::setConfigDefaults([
+            'title' => $title,
+            'hidden' => $config['hidden'] ?? false,
+        ]);
     }
 
     public static function readConfigFile(string $name): array

--- a/src/helpers/Library.php
+++ b/src/helpers/Library.php
@@ -145,15 +145,15 @@ class Library
         $fields = [];
         if (Loader::componentExists($handlePath)) {
             $component = Component::parseComponentParts($handlePath);
-            $context = Context::parseConfigParts($handlePath);
+            // Use lightweight settings method - full context is lazy-loaded via toolbar partial
+            $settings = Context::getTreeSettings($handlePath);
             $fields = [
                 'type' => $component->type,
                 'icon' => $component->icon,
-                'name' => $context->settings->title,
-                'hidden' => $context->settings->hidden,
+                'name' => $settings->title,
+                'hidden' => $settings->hidden,
                 'path' => $component->templatePath,
                 'includeName' => $component->includeName,
-                'context' => $context,
                 'partial_toolbar_url' => self::getPartialUrl($handlePath, 'toolbar'),
                 'is_variant' => $component->isVariant,
                 'is_virtual' => $component->isVirtual,
@@ -169,7 +169,6 @@ class Library
                 'includeName' => $document->includeName,
                 'hidden' => false,
                 'partial_toolbar_url' => null,
-                'context' => null,
             ];
         }
         $pagePreviewUrl = self::getPagePreviewUrl($handlePath);


### PR DESCRIPTION
## Summary

Addresses #44 - Performance degrades with large component libraries because context extraction happens for every component during initial tree building, even though context data is not needed until a user selects a specific component.

### Problem

When the component library browser loads, `Library::getLibraryTree()` scans all directories and for each component file:
1. Calls `Context::parseConfigParts()` which extracts full context
2. `resolveContextReferences()` recursively loads referenced components (e.g., `@modules/card/article`)
3. This happens for ALL ~300+ components before the page renders

For a library with 372 twig files and 233 config files with cross-component references, this creates hundreds of unnecessary file reads and recursive context resolutions.

### Solution

- Add `Context::getTreeSettings()` - a lightweight method that only extracts `title` and `hidden` without resolving context references
- Update `Library::formatFileEntry()` to use the lightweight settings method
- Remove unused `context` key from tree node data (context is already lazy-loaded via the existing toolbar partial endpoint when a component is selected)
- Optimize `getVariants()` to read config file directly instead of using `getComponentConfig()`

### Why this works

The explorer tree template only needs: `name`, `type`, `icon`, `hidden`, URLs, and `includeName`. The full context is already fetched on-demand via `partial_toolbar_url` when a user clicks on a component. This PR simply defers that work until it's actually needed.

### Performance Impact

For libraries with 300+ components and cross-component context references, this eliminates hundreds of recursive context resolutions during initial page load.

## Test Plan

- [ ] Verify component library browser loads faster with large component libraries
- [ ] Verify clicking a component still shows correct context in toolbar
- [ ] Verify variant components display correctly
- [ ] Verify hidden components are still filtered properly
- [ ] Verify search index still works correctly

Fixes #44